### PR TITLE
docs: add linear32, alaw, and ogg-opus encoding options to streaming API

### DIFF
--- a/api-reference/audio-transcriptions/streaming.mdx
+++ b/api-reference/audio-transcriptions/streaming.mdx
@@ -41,14 +41,17 @@ Endpoint:<br/>`wss://api.sully.ai/v1/audio/transcriptions/stream?account_id=1234
 
       <b>Supported formats:</b>
       <ul>
-        <li><code>linear16</code>: 16-bit, little-endian PCM audio</li>
-        <li><code>flac</code>: Free Lossless Audio Codec (FLAC)</li>
-        <li><code>mulaw</code>: Mu-law encoded WAV</li>
-        <li><code>amr-nb</code>: Adaptive Multi-Rate, narrowband</li>
-        <li><code>amr-wb</code>: Adaptive Multi-Rate, wideband</li>
-        <li><code>opus</code>: Ogg Opus codec</li>
-        <li><code>speex</code>: Speex codec</li>
-        <li><code>g729</code>: G729 codec (usable with raw or containerized audio)</li>
+        <li><code>linear16</code>: 16-bit, little-endian, signed PCM WAV data</li>
+        <li><code>linear32</code>: 32-bit, little-endian, floating-point PCM WAV data</li>
+        <li><code>flac</code>: Free Lossless Audio Codec (FLAC) encoded data</li>
+        <li><code>alaw</code>: A-law encoded WAV data</li>
+        <li><code>mulaw</code>: Mu-law encoded WAV data</li>
+        <li><code>amr-nb</code>: Adaptive Multi-Rate (AMR) narrowband codec</li>
+        <li><code>amr-wb</code>: Adaptive Multi-Rate (AMR) wideband codec</li>
+        <li><code>opus</code>: The Opus audio codec</li>
+        <li><code>ogg-opus</code>: The Opus audio codec encapsulated in the Ogg container format</li>
+        <li><code>speex</code>: An open-source, speech-specific audio codec</li>
+        <li><code>g729</code>: G729 low-bandwidth codec (usable with raw or containerized audio)</li>
       </ul>
 </ParamField>
 


### PR DESCRIPTION
## Summary

- Add `linear32` (32-bit floating-point PCM) — used by our browser demo but missing from docs
- Add `alaw` (A-law encoded WAV)
- Add `ogg-opus` (Opus in Ogg container)
- Align all encoding descriptions with Deepgram's official wording

## Test plan

- [ ] Verify encoding list renders correctly in docs preview
- [ ] Confirm `linear32` description matches what the browser demo sends