### PR TITLE
docs: document transcription dictation and stream events

### DIFF
--- a/api-reference-v2/audio-transcriptions/create.mdx
+++ b/api-reference-v2/audio-transcriptions/create.mdx
@@ -2,4 +2,10 @@
 title: 'Create Audio Transcription'
 openapi: 'POST /v2/audio/transcriptions'
 version: 'v2'
---- 
+---
+
+<Note>
+In addition to the multipart form fields shown below, this endpoint accepts an
+optional `dictation` field. Send `dictation=true` to request dictation-oriented
+transcript formatting. If omitted, `dictation` defaults to `false`.
+</Note>

--- a/api-reference/audio-transcriptions/streaming.mdx
+++ b/api-reference/audio-transcriptions/streaming.mdx
@@ -44,10 +44,12 @@ Endpoint:<br/>`wss://api.sully.ai/v1/audio/transcriptions/stream?account_id=1234
         <li><code>linear16</code>: 16-bit, little-endian, signed PCM WAV data</li>
         <li><code>linear32</code>: 32-bit, little-endian, floating-point PCM WAV data</li>
         <li><code>flac</code>: Free Lossless Audio Codec (FLAC) encoded data</li>
+        <li><code>alaw</code>: A-law encoded WAV data</li>
         <li><code>mulaw</code>: Mu-law encoded WAV data</li>
         <li><code>amr-nb</code>: Adaptive Multi-Rate (AMR) narrowband codec</li>
         <li><code>amr-wb</code>: Adaptive Multi-Rate (AMR) wideband codec</li>
         <li><code>opus</code>: The Opus audio codec</li>
+        <li><code>ogg-opus</code>: The Opus audio codec encapsulated in the Ogg container format</li>
         <li><code>speex</code>: An open-source, speech-specific audio codec</li>
         <li><code>g729</code>: G729 low-bandwidth codec (usable with raw or containerized audio)</li>
       </ul>

--- a/api-reference/audio-transcriptions/streaming.mdx
+++ b/api-reference/audio-transcriptions/streaming.mdx
@@ -114,10 +114,12 @@ During a live stream, the server may also send an error message:
 ```
 
 <Note>
-  Treat error messages as advisory. They signal a problem during transcription,
-  but they do not necessarily mean the WebSocket has closed. Continue listening
-  for later transcript or status messages, and reconnect only after the socket
-  closes or you receive a disconnected status.
+  An error message signals a transcription problem, but it does not always mean
+  the session is over. Some runtime error frames are non-terminal and may be
+  followed by later transcript or status messages, while other failures are
+  followed by socket closure. Surface the error immediately, then keep
+  listening for follow-up messages and reconnect when the socket actually
+  closes.
 </Note>
 
 # Streaming input audio

--- a/api-reference/audio-transcriptions/streaming.mdx
+++ b/api-reference/audio-transcriptions/streaming.mdx
@@ -44,15 +44,17 @@ Endpoint:<br/>`wss://api.sully.ai/v1/audio/transcriptions/stream?account_id=1234
         <li><code>linear16</code>: 16-bit, little-endian, signed PCM WAV data</li>
         <li><code>linear32</code>: 32-bit, little-endian, floating-point PCM WAV data</li>
         <li><code>flac</code>: Free Lossless Audio Codec (FLAC) encoded data</li>
-        <li><code>alaw</code>: A-law encoded WAV data</li>
         <li><code>mulaw</code>: Mu-law encoded WAV data</li>
         <li><code>amr-nb</code>: Adaptive Multi-Rate (AMR) narrowband codec</li>
         <li><code>amr-wb</code>: Adaptive Multi-Rate (AMR) wideband codec</li>
         <li><code>opus</code>: The Opus audio codec</li>
-        <li><code>ogg-opus</code>: The Opus audio codec encapsulated in the Ogg container format</li>
         <li><code>speex</code>: An open-source, speech-specific audio codec</li>
         <li><code>g729</code>: G729 low-bandwidth codec (usable with raw or containerized audio)</li>
       </ul>
+</ParamField>
+
+<ParamField query="dictation" type="boolean" default="false">
+    Requests dictation-oriented transcript formatting for the stream.
 </ParamField>
 
 <ParamField query="account_id" type="string">
@@ -77,7 +79,9 @@ Upon successful connection, the server sends a status message:
 
 ```json
 {
+  "type": "status",
   "status": "connected",
+  "timestamp": "2026-04-22T14:32:07.123Z"
 }
 ```
 
@@ -85,12 +89,33 @@ When the connection closes:
 
 ```json
 {
+  "type": "status",
   "status": "disconnected",
+  "timestamp": "2026-04-22T14:32:17.123Z"
 }
 ```
 
 <Note>
-  **Important:** Wait for the "status": "connected" message before sending audio data. This ensures the server is ready to process your stream.
+  **Important:** Wait for the `type: "status"` / `status: "connected"` message before sending audio data. This ensures the server is ready to process your stream.
+</Note>
+
+## Error Messages
+
+During a live stream, the server may also send an error message:
+
+```json
+{
+  "type": "error",
+  "error": "An error occurred during transcription",
+  "timestamp": "2026-04-22T14:32:12.123Z"
+}
+```
+
+<Note>
+  Treat error messages as advisory. They signal a problem during transcription,
+  but they do not necessarily mean the WebSocket has closed. Continue listening
+  for later transcript or status messages, and reconnect only after the socket
+  closes or you receive a disconnected status.
 </Note>
 
 # Streaming input audio
@@ -112,7 +137,7 @@ The client can send messages with audio input to the server. The messages can co
 
 ## Streaming output audio
 
-The server will always respond with a message containing the following fields:
+Transcript messages contain the following fields:
 
 ```json Response message
 {

--- a/api-reference/audio-transcriptions/streaming.mdx
+++ b/api-reference/audio-transcriptions/streaming.mdx
@@ -29,15 +29,16 @@ Endpoint:<br/>`wss://api.sully.ai/v1/audio/transcriptions/stream?account_id=1234
     The language of your submitted audio. See our [Supported Languages](/api-reference/audio-transcriptions/languages) documentation for a complete list of language options.
 </ParamField>
 
-<ParamField query="sample_rate" type="string">
-    The sample rate of your submitted audio.
+<ParamField query="sample_rate" type="string" default="16000">
+    The sample rate of your submitted audio. If omitted, the streaming service currently defaults to `16000`.
+    For raw, headerless audio, send the actual sample rate of your stream explicitly.
 </ParamField>
 
 <ParamField query="encoding" type="string">
       Specifies the encoding format of the audio being sent.
       
-      <b>Important:</b> This parameter is <b>required</b> when transmitting raw, unstructured audio packets without headers. 
-      If the audio data is encapsulated within a container format, this parameter should be omitted.
+      <b>Important:</b> This parameter is <b>required</b> when transmitting raw, unstructured audio packets without headers.
+      If the audio data is encapsulated within a container format, this parameter should be omitted. When <code>sample_rate</code> is omitted, the streaming service currently still defaults it to <code>16000</code>.
 
       <b>Supported formats:</b>
       <ul>

--- a/documentation/guides/transcription.mdx
+++ b/documentation/guides/transcription.mdx
@@ -117,6 +117,66 @@ curl -X GET "https://api.sully.ai/v2/audio/transcriptions/tr_abc123" \
 ```
 </CodeGroup>
 
+### Dictation Formatting
+
+If you want prerecorded transcript output formatted for dictation workflows,
+add the optional `dictation` field and set it to `true`. If omitted,
+`dictation` defaults to `false`.
+
+<CodeGroup>
+```typescript TypeScript
+import { readFile } from 'fs/promises';
+
+const audioBytes = await readFile('./patient-visit.mp3');
+const formData = new FormData();
+
+formData.append(
+  'audio',
+  new File([audioBytes], 'patient-visit.mp3', { type: 'audio/mpeg' })
+);
+formData.append('dictation', 'true');
+
+await fetch('https://api.sully.ai/v2/audio/transcriptions', {
+  method: 'POST',
+  headers: {
+    'X-API-Key': process.env.SULLY_API_KEY!,
+    'X-Account-Id': process.env.SULLY_ACCOUNT_ID!,
+  },
+  body: formData,
+});
+```
+
+```python Python
+import os
+import requests
+
+with open("patient-visit.mp3", "rb") as audio_file:
+    response = requests.post(
+        "https://api.sully.ai/v2/audio/transcriptions",
+        headers={
+            "X-API-Key": os.environ["SULLY_API_KEY"],
+            "X-Account-Id": os.environ["SULLY_ACCOUNT_ID"],
+        },
+        files={
+            "audio": ("patient-visit.mp3", audio_file, "audio/mpeg"),
+        },
+        data={
+            "dictation": "true",
+        },
+    )
+
+response.raise_for_status()
+```
+
+```bash HTTP
+curl -X POST "https://api.sully.ai/v2/audio/transcriptions" \
+  -H "X-API-Key: ${SULLY_API_KEY}" \
+  -H "X-Account-Id: ${SULLY_ACCOUNT_ID}" \
+  -F "audio=@./patient-visit.mp3" \
+  -F "dictation=true"
+```
+</CodeGroup>
+
 ### Status Lifecycle
 
 | Status | Description |
@@ -139,9 +199,10 @@ Stream audio in real-time during patient visits for immediate transcription feed
 ```
 1. Get token     POST /v1/audio/transcriptions/stream/token
 2. Connect       wss://api.sully.ai/v1/audio/transcriptions/stream?...
-3. Send audio    { "audio": "<base64-encoded-audio>" }
-4. Receive text  { "text": "...", "isFinal": true/false }
-5. Close         ws.close()
+3. Wait for      { "type": "status", "status": "connected" }
+4. Send audio    { "audio": "<base64-encoded-audio>" }
+5. Receive       status, transcript, and advisory error messages
+6. Close         ws.close()
 ```
 
 ### Get a Streaming Token
@@ -202,8 +263,18 @@ wss://api.sully.ai/v1/audio/transcriptions/stream?sample_rate=16000&account_id={
 | `account_id` | Yes | Your Sully account ID |
 | `api_token` | Yes | Token from the stream token endpoint |
 | `language` | No | BCP47 language tag (e.g., `en`, `es`, `multi`) |
+| `dictation` | No | Set to `true` to request dictation-oriented transcript formatting |
 
 ### Message Format
+
+**Stream ready:**
+```json
+{
+  "type": "status",
+  "status": "connected",
+  "timestamp": "2026-04-22T14:32:07.123Z"
+}
+```
 
 **Sending audio:**
 ```json
@@ -213,13 +284,28 @@ wss://api.sully.ai/v1/audio/transcriptions/stream?sample_rate=16000&account_id={
 **Receiving transcription:**
 ```json
 {
+  "type": "transcript",
   "text": "The patient reports feeling tired",
-  "isFinal": false
+  "isFinal": false,
+  "is_final": false
 }
 ```
 
+**Advisory error message:**
+```json
+{
+  "type": "error",
+  "error": "An error occurred during transcription",
+  "timestamp": "2026-04-22T14:32:12.123Z"
+}
+```
+
+- Wait for the `status: connected` message before sending audio
 - `text`: The transcribed text for the current segment
-- `isFinal`: When `true`, this segment is complete and will not change
+- `is_final`: Canonical finality flag for the current segment
+- `isFinal`: Compatibility alias for `is_final`
+- `type: "error"` indicates a transcription problem, but it does not by itself
+  mean the socket has closed
 
 ### Basic WebSocket Connection
 
@@ -237,19 +323,31 @@ const ws = new WebSocket(
 // Track transcription segments
 const segments: string[] = [];
 let currentIndex = 0;
+let streamReady = false;
 
 ws.onopen = () => {
-  console.log('Connected to transcription stream');
+  console.log('Socket opened, waiting for stream readiness...');
 };
 
 ws.onmessage = (event) => {
   const data = JSON.parse(event.data);
 
-  if (data.text) {
-    segments[currentIndex] = data.text;
+  if (data.type === 'status') {
+    streamReady = data.status === 'connected';
+    console.log(`Stream status: ${data.status}`);
+    return;
+  }
 
-    // isFinal indicates this segment is complete
-    if (data.isFinal) {
+  if (data.type === 'error') {
+    console.warn('Transcription stream error:', data.error);
+    return;
+  }
+
+  if (data.type === 'transcript' && data.text) {
+    segments[currentIndex] = data.text;
+    const isFinal = data.is_final ?? data.isFinal ?? false;
+
+    if (isFinal) {
       console.log(`Segment ${currentIndex}: ${data.text}`);
       currentIndex++;
     }
@@ -268,6 +366,11 @@ ws.onclose = (event) => {
 
 // Send audio data (from microphone, file, etc.)
 function sendAudio(audioBuffer: ArrayBuffer) {
+  if (!streamReady) {
+    console.warn('Stream not ready yet; wait for the connected status message.');
+    return;
+  }
+
   const base64Audio = btoa(
     String.fromCharCode(...new Uint8Array(audioBuffer))
   );
@@ -291,25 +394,41 @@ async def stream_transcription():
 
     segments = []
     current_index = 0
+    stream_ready = False
 
     async with websockets.connect(url) as ws:
-        print("Connected to transcription stream")
+        print("Socket opened, waiting for stream readiness...")
 
         async def receive_messages():
-            nonlocal current_index
+            nonlocal current_index, stream_ready
             async for message in ws:
                 data = json.loads(message)
-                if "text" in data:
+
+                if data.get("type") == "status":
+                    stream_ready = data.get("status") == "connected"
+                    print(f"Stream status: {data.get('status')}")
+                    continue
+
+                if data.get("type") == "error":
+                    print(f"Transcription stream error: {data.get('error')}")
+                    continue
+
+                if data.get("type") == "transcript" and "text" in data:
                     # Extend segments list if needed
                     while len(segments) <= current_index:
                         segments.append("")
                     segments[current_index] = data["text"]
 
-                    if data.get("isFinal"):
+                    is_final = data.get("is_final", data.get("isFinal", False))
+                    if is_final:
                         print(f"Segment {current_index}: {data['text']}")
                         current_index += 1
 
         async def send_audio(audio_data: bytes):
+            if not stream_ready:
+                print("Stream not ready yet; wait for the connected status message.")
+                return
+
             base64_audio = base64.b64encode(audio_data).decode("utf-8")
             await ws.send(json.dumps({"audio": base64_audio}))
 
@@ -339,6 +458,7 @@ Real-time audio streaming in production requires handling network interruptions,
 2. **Token expiration** - Streaming tokens have limited validity
 3. **Audio continuity** - Buffering audio during reconnection to prevent data loss
 4. **State recovery** - Resuming transcription context after reconnection
+5. **Advisory error frames** - Some server error messages do not immediately close the socket
 
 ### Reconnection with Exponential Backoff
 
@@ -366,6 +486,13 @@ function calculateBackoff(
 ### Production WebSocket Implementation
 
 The following implementation handles reconnection, audio buffering, and error recovery:
+
+<Note>
+This example reconnects on close events and connection failures. In your own
+implementation, treat `type: "error"` messages as advisory stream events:
+surface them to the caller, but do not force a reconnect unless the socket
+actually closes.
+</Note>
 
 <CodeGroup>
 ```typescript TypeScript
@@ -1037,6 +1164,7 @@ if __name__ == "__main__":
 | Token expired (401) | Fetch new token, reconnect |
 | Rate limited (429) | Use `Retry-After` header, increase backoff |
 | Server error (5xx) | Retry with backoff |
+| WebSocket error message | Surface to caller, keep listening, reconnect only if the socket closes |
 | Invalid audio format | Check sample rate, encoding |
 | Network disconnect | Reconnect with buffered audio |
 

--- a/documentation/guides/transcription.mdx
+++ b/documentation/guides/transcription.mdx
@@ -201,7 +201,7 @@ Stream audio in real-time during patient visits for immediate transcription feed
 2. Connect       wss://api.sully.ai/v1/audio/transcriptions/stream?...
 3. Wait for      { "type": "status", "status": "connected" }
 4. Send audio    { "audio": "<base64-encoded-audio>" }
-5. Receive       status, transcript, and advisory error messages
+5. Receive       status, transcript, and error messages
 6. Close         ws.close()
 ```
 
@@ -291,7 +291,7 @@ wss://api.sully.ai/v1/audio/transcriptions/stream?sample_rate=16000&account_id={
 }
 ```
 
-**Advisory error message:**
+**Error message:**
 ```json
 {
   "type": "error",
@@ -304,8 +304,8 @@ wss://api.sully.ai/v1/audio/transcriptions/stream?sample_rate=16000&account_id={
 - `text`: The transcribed text for the current segment
 - `is_final`: Canonical finality flag for the current segment
 - `isFinal`: Compatibility alias for `is_final`
-- `type: "error"` indicates a transcription problem, but it does not by itself
-  mean the socket has closed
+- `type: "error"` indicates a transcription problem. Some runtime errors are
+  non-terminal, while other failures are followed by socket closure.
 
 ### Basic WebSocket Connection
 
@@ -458,7 +458,7 @@ Real-time audio streaming in production requires handling network interruptions,
 2. **Token expiration** - Streaming tokens have limited validity
 3. **Audio continuity** - Buffering audio during reconnection to prevent data loss
 4. **State recovery** - Resuming transcription context after reconnection
-5. **Advisory error frames** - Some server error messages do not immediately close the socket
+5. **Error frames** - Some server error messages are non-terminal, while others precede disconnects
 
 ### Reconnection with Exponential Backoff
 
@@ -489,9 +489,9 @@ The following implementation handles reconnection, audio buffering, and error re
 
 <Note>
 This example reconnects on close events and connection failures. In your own
-implementation, treat `type: "error"` messages as advisory stream events:
-surface them to the caller, but do not force a reconnect unless the socket
-actually closes.
+implementation, surface `type: "error"` messages immediately, but do not assume
+every error frame is terminal. Some runtime errors are followed by later stream
+messages, while other failures are followed by socket closure.
 </Note>
 
 <CodeGroup>
@@ -1164,7 +1164,7 @@ if __name__ == "__main__":
 | Token expired (401) | Fetch new token, reconnect |
 | Rate limited (429) | Use `Retry-After` header, increase backoff |
 | Server error (5xx) | Retry with backoff |
-| WebSocket error message | Surface to caller, keep listening, reconnect only if the socket closes |
+| WebSocket error message | Surface to caller, keep listening for follow-up messages, reconnect if the socket closes |
 | Invalid audio format | Check sample rate, encoding |
 | Network disconnect | Reconnect with buffered audio |
 

--- a/documentation/guides/transcription.mdx
+++ b/documentation/guides/transcription.mdx
@@ -259,11 +259,17 @@ wss://api.sully.ai/v1/audio/transcriptions/stream?sample_rate=16000&account_id={
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `sample_rate` | Yes | Audio sample rate in Hz (e.g., `16000`, `44100`) |
+| `sample_rate` | No | Audio sample rate in Hz (e.g., `16000`, `44100`). If omitted, the streaming service currently defaults to `16000`. For raw, headerless audio, send the actual sample rate explicitly. |
 | `account_id` | Yes | Your Sully account ID |
 | `api_token` | Yes | Token from the stream token endpoint |
 | `language` | No | BCP47 language tag (e.g., `en`, `es`, `multi`) |
 | `dictation` | No | Set to `true` to request dictation-oriented transcript formatting |
+
+<Note>
+For raw, headerless audio, send both `encoding` and `sample_rate`. For
+containerized audio, omit `encoding`. If `sample_rate` is omitted, the current
+streaming service still defaults it to `16000`.
+</Note>
 
 ### Message Format
 

--- a/documentation/production/error-handling.mdx
+++ b/documentation/production/error-handling.mdx
@@ -428,7 +428,7 @@ SDK errors include helpful properties for debugging and logging:
 
 ## WebSocket Error Recovery
 
-Real-time streaming connections require special error handling for connection drops, token expiration, advisory error messages, and state recovery.
+Real-time streaming connections require special error handling for connection drops, token expiration, server error messages that may or may not be terminal, and state recovery.
 
 ### Connection Drops
 
@@ -463,7 +463,7 @@ class StreamConnection {
 
 ### Server Error Messages
 
-The streaming API can send advisory error frames while the socket remains open:
+The streaming API can send error frames before either continuing the session or closing it:
 
 ```json
 {
@@ -496,9 +496,11 @@ ws.onmessage = (event) => {
 ```
 
 <Note>
-Treat `type: "error"` messages as advisory. Surface them to logs or the UI, but
-continue listening for later transcript or status messages. Reconnect only after
-the socket closes or your client detects another terminal condition.
+Treat `type: "error"` messages as signals to surface immediately, not as a
+definitive reconnect trigger. Some runtime errors are followed by later
+transcript or status messages, while other failures are followed by socket
+closure. Reconnect when the socket closes or another terminal condition is
+observed.
 </Note>
 
 ### Token Expiration

--- a/documentation/production/error-handling.mdx
+++ b/documentation/production/error-handling.mdx
@@ -428,7 +428,7 @@ SDK errors include helpful properties for debugging and logging:
 
 ## WebSocket Error Recovery
 
-Real-time streaming connections require special error handling for connection drops, token expiration, and state recovery.
+Real-time streaming connections require special error handling for connection drops, token expiration, advisory error messages, and state recovery.
 
 ### Connection Drops
 
@@ -460,6 +460,46 @@ class StreamConnection {
   }
 }
 ```
+
+### Server Error Messages
+
+The streaming API can send advisory error frames while the socket remains open:
+
+```json
+{
+  "type": "error",
+  "error": "An error occurred during transcription",
+  "timestamp": "2026-04-22T14:32:12.123Z"
+}
+```
+
+Handle these separately from disconnects:
+
+```typescript
+ws.onmessage = (event) => {
+  const message = JSON.parse(event.data);
+
+  if (message.type === 'error') {
+    console.warn('Streaming transcription error:', message.error);
+    return;
+  }
+
+  if (message.type === 'status') {
+    console.log(`Streaming status: ${message.status}`);
+    return;
+  }
+
+  if (message.type === 'transcript') {
+    // Process transcript segment here
+  }
+};
+```
+
+<Note>
+Treat `type: "error"` messages as advisory. Surface them to logs or the UI, but
+continue listening for later transcript or status messages. Reconnect only after
+the socket closes or your client detects another terminal condition.
+</Note>
 
 ### Token Expiration
 


### PR DESCRIPTION
## Summary

Document the public transcription API changes from the recent copilot updates without exposing backend provider details.

## Changes

- add `dictation` coverage to the v2 transcription reference page and the transcription guide
- update the streaming reference and guide to document `status`, `transcript`, and advisory `error` WebSocket messages
- clarify that clients should wait for the connected status before sending audio and should reconnect on socket closure, not every error frame
- remove stale streaming encoding values that no longer match the documented accepted set

## Testing

- `git diff --check -- api-reference-v2/audio-transcriptions/create.mdx api-reference/audio-transcriptions/streaming.mdx documentation/guides/transcription.mdx documentation/production/error-handling.mdx`
- `rg -n 'deepgram|Deepgram|speechmatics|Speechmatics' api-reference-v2/audio-transcriptions/create.mdx api-reference/audio-transcriptions/streaming.mdx documentation/guides/transcription.mdx documentation/production/error-handling.mdx`
- `mintlify` not installed in this workspace, so no local render/CLI validation was run